### PR TITLE
Publish as vercel-source-recovery on npm

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,66 @@
+# Update to Vercel API v8 with Source-Only Downloads
+
+## Summary
+
+This PR updates the tool to use Vercel's latest API (v8) and adds intelligent filtering to download only source files, excluding build outputs. These changes significantly improve reliability and usability.
+
+## Key Changes
+
+### 🚀 API Migration
+- Updated from Vercel API v6 to v8 for improved reliability
+- Implemented proper base64 decoding for file contents
+- Added support for both UID-based and path-based file access
+
+### 📁 Source-Only Downloads
+- Automatically filters out the `out/` directory (build outputs)
+- Skips lambda and edge functions that aren't directly downloadable
+- Focuses on retrieving actual source code files
+
+### 🐛 Bug Fixes
+- Fixed path normalization issues for nested directories
+- Improved error handling for 404 and 410 responses
+- Better handling of symlinks and special file types
+
+### 📚 Documentation
+- Completely revamped README with comprehensive documentation
+- Added troubleshooting section for common issues
+- Included technical implementation details
+
+## Testing
+
+Tested with multiple Vercel deployments:
+- ✅ Successfully downloads source files from `src/` directory
+- ✅ Preserves directory structure correctly
+- ✅ Handles nested directories and complex file paths
+- ✅ Gracefully skips non-downloadable files
+- ✅ Works with both personal and team projects
+
+## Why These Changes?
+
+1. **API v8 is the current stable version** - v6 endpoints were returning 404 errors for many file operations
+2. **Users typically want source files** - Excluding build outputs saves time and storage
+3. **Better error handling** - The tool now gracefully handles various edge cases instead of failing
+
+## Breaking Changes
+
+None - the tool maintains the same user interface and workflow.
+
+## Screenshots/Output
+
+Example output showing successful source file download:
+```
+Processing: src (type: directory, uid: none, has children: true)
+  Processing 34 children of src
+Processing: .eslintrc.json (type: file, uid: 86be0bfec6a6c98d9f12aa5149d3cd49669e0c0f, has children: false)
+  Trying URL: https://vercel.com/api/v8/deployments/dpl_XXX/files/86be0bfec6a6c98d9f12aa5149d3cd49669e0c0f (UID-based)
+  Successfully downloaded .eslintrc.json
+Skipping 'out' directory and all its contents
+```
+
+## Related Issues
+
+This update addresses common issues users have reported with downloading source files from Vercel deployments.
+
+---
+
+I've tested these changes extensively and they significantly improve the tool's reliability and user experience. Happy to make any adjustments based on your feedback!

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# source-from-vercel-deployment
+# vercel-source-recovery
 
 Download source files from your Vercel deployments. This tool allows you to recover your source code directly from Vercel deployments when you need to retrieve your files.
 
-[![npm version](https://img.shields.io/npm/v/source-from-vercel-deployment.svg)](https://www.npmjs.com/package/source-from-vercel-deployment)
+[![npm version](https://img.shields.io/npm/v/vercel-source-recovery.svg)](https://www.npmjs.com/package/vercel-source-recovery)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 ## 🚀 Features
@@ -19,24 +19,24 @@ Download source files from your Vercel deployments. This tool allows you to reco
 
 ### Global Installation (Recommended)
 ```bash
-npm install -g source-from-vercel-deployment
+npm install -g vercel-source-recovery
 ```
 
 ### Using npx (No Installation)
 ```bash
-npx source-from-vercel-deployment
+npx vercel-source-recovery
 ```
 
 ### Local Installation
 ```bash
-npm install source-from-vercel-deployment
+npm install vercel-source-recovery
 ```
 
 ## 🎯 Quick Start
 
 Simply run:
 ```bash
-source-from-vercel-deployment
+vercel-source-recovery
 ```
 
 The interactive CLI will guide you through:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "source-from-vercel-deployment",
-  "version": "4.1.0",
-  "description": "A simple package made for downloading the source code from your Vercel Deployment.",
+  "name": "vercel-source-recovery",
+  "version": "1.0.0",
+  "description": "Download and recover source files from your Vercel deployments. Uses Vercel API v8 for reliable source code recovery.",
   "main": "dist/index.js",
   "scripts": {
     "start": "npm run build && node dist/index.js",
@@ -22,7 +22,7 @@
       "^.*\\((.*)\\): (.*)": "* **$1** $2"
     }
   },
-  "author": "Cristian Calina",
+  "author": "Cristian Calina, sigaihealth",
   "license": "MIT",
   "dependencies": {
     "axios": "^0.21.1",
@@ -41,21 +41,27 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/CalinaCristian/source-from-vercel-deployment.git"
+    "url": "git+https://github.com/sigaihealth/vercelsourcerecover.git"
   },
   "bin": {
-    "source-from-vercel-deployment": "dist/index.js"
+    "vercel-source-recovery": "dist/index.js"
   },
   "keywords": [
     "vercel",
     "deployment",
     "download",
-    "download-vercel-deployment",
-    "next",
-    "vercel-deployment"
+    "source",
+    "recovery",
+    "backup",
+    "vercel-api",
+    "vercel-deployment",
+    "source-code",
+    "disaster-recovery",
+    "vercel-backup",
+    "code-recovery"
   ],
   "bugs": {
-    "url": "https://github.com/CalinaCristian/source-from-vercel-deployment/issues"
+    "url": "https://github.com/sigaihealth/vercelsourcerecover/issues"
   },
-  "homepage": "https://github.com/CalinaCristian/source-from-vercel-deployment#readme"
+  "homepage": "https://github.com/sigaihealth/vercelsourcerecover#readme"
 }


### PR DESCRIPTION
- Changed package name to vercel-source-recovery
- Updated version to 1.0.0
- Updated repository URLs to point to sigaihealth/vercelsourcerecover
- Updated README with new package name
- Added more relevant keywords for npm discoverability
- Published to npm registry